### PR TITLE
Render negative times

### DIFF
--- a/src/format-time.ts
+++ b/src/format-time.ts
@@ -11,7 +11,14 @@
 type Resolution = "seconds"|"minutes"|"automatic";
 
 
-const leftPad = (num: number) => (num < 10 ? `0${num}` : num);
+const leftPad = (num: number) => {
+  num = Math.abs(num);
+  return (num < 10 ? `0${num}` : num);
+};
+
+
+/** Rounds away from zero. */
+const roundUp = (num: number) => num > 0 ? Math.ceil(num) : Math.floor(num);
 
 /** Returns "minutes" if seconds>=1hr, otherwise minutes. */
 function automaticRes(seconds: number) {
@@ -28,20 +35,18 @@ export function formatFromResolution(seconds: number, resolution: Resolution): s
 }
 
 function joinWithColons(h: number, m: number, s: number): string {
-  if (h > 0) return `${h}:${leftPad(m)}:${leftPad(s)}`;
-  if (m > 0) return `${m}:${leftPad(s)}`;
+  if (h) return `${h}:${leftPad(m)}:${leftPad(s)}`;
+  if (m) return `${m}:${leftPad(s)}`;
   return "" + s;
 }
 const hmsTime = (d: number) => {
-  if (d < 0) return '-' + hmsTime(-d);
-  const h = Math.floor(d / 3600);
-  const m = Math.floor((d % 3600) / 60);
-  const s = Math.floor((d % 3600) % 60);
+  const h = Math.trunc(d / 3600);
+  const m = Math.trunc((d % 3600) / 60);
+  const s = Math.trunc((d % 3600) % 60);
   return joinWithColons(h, m, s);
 }
 const hmTime = (d: number) => {
-  if (d < 0) return '-' + hmTime(-d);
-  const h = Math.floor(d / 3600);
+  const h = Math.trunc(d / 3600);
   const m = Math.ceil((d % 3600) / 60); // Round up the minutes (#86)
   return joinWithColons(0, h, m);
 }
@@ -49,29 +54,29 @@ const hmTime = (d: number) => {
 export default function formatTime(d: number, format: string) {
   if (format == 'hms') return hmsTime(d)
   if (format == 'hm') return hmTime(d)
-  if (format == 'd') return ''+Math.ceil(d / 24 / 3600)
-  if (format == 'h') return ''+Math.ceil(d / 3600)
-  if (format == 'm') return ''+Math.ceil(d / 60)
-  if (format == 's') return ''+Math.ceil(d)
+  if (format == 'd') return ''+roundUp(d / 24 / 3600)
+  if (format == 'h') return ''+roundUp(d / 3600)
+  if (format == 'm') return ''+roundUp(d / 60)
+  if (format == 's') return ''+roundUp(d)
 
   return format.replace(/%(\w+)/g, (match, S) => {
     const sl = S.toLowerCase()
     if (sl.startsWith('hms')) return hmsTime(d) + S.substring(3)
     if (sl.startsWith('hm')) return hmTime(d) + S.substring(2)
-    // 1 lowercase letter: ceil
-    if (S.startsWith('d')) return Math.ceil(d / 24 / 3600) + S.substring(1)
-    if (S.startsWith('h')) return Math.ceil(d / 3600) + S.substring(1)
-    if (S.startsWith('m')) return Math.ceil(d / 60) + S.substring(1)
-    if (S.startsWith('s')) return Math.ceil(d) + S.substring(1)
-    // 2 capital letter: pad + floor
-    if (S.startsWith('HH')) return leftPad(Math.floor((d % (3600 * 24)) / 3600)) + S.substring(2)
-    if (S.startsWith('MM')) return leftPad(Math.floor((d % 3600) / 60)) + S.substring(2)
-    if (S.startsWith('SS')) return leftPad(Math.floor(d % 60)) + S.substring(2)
-    // 1 capital letter: floor
-    if (S.startsWith('D')) return Math.floor(d / 24 / 3600) + S.substring(1)
-    if (S.startsWith('H')) return Math.floor((d % (3600 * 24)) / 3600) + S.substring(1)
-    if (S.startsWith('M')) return Math.floor((d % 3600) / 60) + S.substring(1)
-    if (S.startsWith('S')) return Math.floor(d % 60) + S.substring(1)
+    // 1 lowercase letter: round up
+    if (S.startsWith('d')) return roundUp(d / 24 / 3600) + S.substring(1)
+    if (S.startsWith('h')) return roundUp(d / 3600) + S.substring(1)
+    if (S.startsWith('m')) return roundUp(d / 60) + S.substring(1)
+    if (S.startsWith('s')) return roundUp(d) + S.substring(1)
+    // 2 capital letter: pad + round down
+    if (S.startsWith('HH')) return leftPad(Math.trunc((d % (3600 * 24)) / 3600)) + S.substring(2)
+    if (S.startsWith('MM')) return leftPad(Math.trunc((d % 3600) / 60)) + S.substring(2)
+    if (S.startsWith('SS')) return leftPad(Math.trunc(d % 60)) + S.substring(2)
+    // 1 capital letter: round down
+    if (S.startsWith('D')) return Math.trunc(d / 24 / 3600) + S.substring(1)
+    if (S.startsWith('H')) return Math.trunc((d % (3600 * 24)) / 3600) + S.substring(1)
+    if (S.startsWith('M')) return Math.trunc((d % 3600) / 60) + S.substring(1)
+    if (S.startsWith('S')) return Math.trunc(d % 60) + S.substring(1)
     return match
   })
 }

--- a/src/format-time.ts
+++ b/src/format-time.ts
@@ -8,7 +8,7 @@
     EDIT: This has been turned into a general-purpose time formatting library.
 */
 
-type Resolution = "seconds"|"minutes"|"automatic";
+type Resolution = "seconds" | "minutes" | "automatic";
 
 
 const leftPad = (num: number) => {
@@ -22,8 +22,8 @@ const roundUp = (num: number) => num > 0 ? Math.ceil(num) : Math.floor(num);
 
 /** Returns "minutes" if seconds>=1hr, otherwise minutes. */
 function automaticRes(seconds: number) {
-    if (seconds >= 3600) return "minutes"
-    return "seconds"
+  if (seconds >= 3600) return "minutes"
+  return "seconds"
 }
 
 
@@ -51,32 +51,44 @@ const hmTime = (d: number) => {
   return joinWithColons(0, h, m);
 }
 
+/** Like Math.truncate(), but truncates `-.5` to `'-0'` */
+function truncateWithSign(d: number): string {
+  const result = Math.trunc(d);
+  if (d < 0 && result === 0) return `-${-result}`;
+  return result.toString();
+}
+
 export default function formatTime(d: number, format: string) {
   if (format == 'hms') return hmsTime(d)
   if (format == 'hm') return hmTime(d)
-  if (format == 'd') return ''+roundUp(d / 24 / 3600)
-  if (format == 'h') return ''+roundUp(d / 3600)
-  if (format == 'm') return ''+roundUp(d / 60)
-  if (format == 's') return ''+roundUp(d)
 
+  // When rendering a single component, always round up to count consistent whole units.
+  if (format == 'd') return '' + Math.ceil(d / 24 / 3600)
+  if (format == 'h') return '' + Math.ceil(d / 3600)
+  if (format == 'm') return '' + Math.ceil(d / 60)
+  if (format == 's') return '' + Math.ceil(d)
+
+
+  // When rendering multiple components, round towards zero because the fraction should
+  // be represented by the next unit.
   return format.replace(/%(\w+)/g, (match, S) => {
     const sl = S.toLowerCase()
     if (sl.startsWith('hms')) return hmsTime(d) + S.substring(3)
     if (sl.startsWith('hm')) return hmTime(d) + S.substring(2)
     // 1 lowercase letter: round up
-    if (S.startsWith('d')) return roundUp(d / 24 / 3600) + S.substring(1)
-    if (S.startsWith('h')) return roundUp(d / 3600) + S.substring(1)
-    if (S.startsWith('m')) return roundUp(d / 60) + S.substring(1)
-    if (S.startsWith('s')) return roundUp(d) + S.substring(1)
+    if (S.startsWith('d')) return Math.ceil(d / 24 / 3600) + S.substring(1)
+    if (S.startsWith('h')) return Math.ceil(d / 3600) + S.substring(1)
+    if (S.startsWith('m')) return Math.ceil(d / 60) + S.substring(1)
+    if (S.startsWith('s')) return Math.ceil(d) + S.substring(1)
     // 2 capital letter: pad + round down
     if (S.startsWith('HH')) return leftPad(Math.trunc((d % (3600 * 24)) / 3600)) + S.substring(2)
     if (S.startsWith('MM')) return leftPad(Math.trunc((d % 3600) / 60)) + S.substring(2)
     if (S.startsWith('SS')) return leftPad(Math.trunc(d % 60)) + S.substring(2)
-    // 1 capital letter: round down
-    if (S.startsWith('D')) return Math.trunc(d / 24 / 3600) + S.substring(1)
-    if (S.startsWith('H')) return Math.trunc((d % (3600 * 24)) / 3600) + S.substring(1)
-    if (S.startsWith('M')) return Math.trunc((d % 3600) / 60) + S.substring(1)
-    if (S.startsWith('S')) return Math.trunc(d % 60) + S.substring(1)
+    // 1 capital letter: round down, always include sign (for next component)
+    if (S.startsWith('D')) return truncateWithSign(d / 24 / 3600) + S.substring(1)
+    if (S.startsWith('H')) return truncateWithSign((d % (3600 * 24)) / 3600) + S.substring(1)
+    if (S.startsWith('M')) return truncateWithSign((d % 3600) / 60) + S.substring(1)
+    if (S.startsWith('S')) return truncateWithSign(d % 60) + S.substring(1)
     return match
   })
 }

--- a/src/format-time.ts
+++ b/src/format-time.ts
@@ -33,12 +33,14 @@ function joinWithColons(h: number, m: number, s: number): string {
   return "" + s;
 }
 const hmsTime = (d: number) => {
+  if (d < 0) return '-' + hmsTime(-d);
   const h = Math.floor(d / 3600);
   const m = Math.floor((d % 3600) / 60);
   const s = Math.floor((d % 3600) % 60);
   return joinWithColons(h, m, s);
 }
 const hmTime = (d: number) => {
+  if (d < 0) return '-' + hmTime(-d);
   const h = Math.floor(d / 3600);
   const m = Math.ceil((d % 3600) / 60); // Round up the minutes (#86)
   return joinWithColons(0, h, m);

--- a/test/format-time.test.ts
+++ b/test/format-time.test.ts
@@ -31,7 +31,7 @@ it("Can render longer times", () => {
     
     expect(formatTime(-d, 'hms')).toBe('-1:40')
     expect(formatTime(-d, 'hm')).toBe('-1')
-    expect(formatTime(-d, 'd')).toBe('-1')
+    expect(formatTime(-d, 'd')).toBe('0')
 });
 
 it("Can render long times", () => {
@@ -50,6 +50,6 @@ it("Can render long times", () => {
     
     expect(formatTime(-d, 'hms')).toBe('-2:46:40')
     expect(formatTime(-d, 'hm')).toBe('-2:46')
-    expect(formatTime(-d, 'h')).toBe('-3')
-    expect(formatTime(-d, 'm')).toBe('-167')
+    expect(formatTime(-d, 'h')).toBe('-2')
+    expect(formatTime(-d, 'm')).toBe('-166')
 });

--- a/test/format-time.test.ts
+++ b/test/format-time.test.ts
@@ -31,7 +31,7 @@ it("Can render longer times", () => {
     
     expect(formatTime(-d, 'hms')).toBe('-1:40')
     expect(formatTime(-d, 'hm')).toBe('-1')
-    expect(formatTime(-d, 'd')).toBe('0')
+    expect(formatTime(-d, 'd')).toBe('-1')
 });
 
 it("Can render long times", () => {
@@ -50,5 +50,6 @@ it("Can render long times", () => {
     
     expect(formatTime(-d, 'hms')).toBe('-2:46:40')
     expect(formatTime(-d, 'hm')).toBe('-2:46')
-    expect(formatTime(-d, 'h')).toBe('-2')
+    expect(formatTime(-d, 'h')).toBe('-3')
+    expect(formatTime(-d, 'm')).toBe('-167')
 });

--- a/test/format-time.test.ts
+++ b/test/format-time.test.ts
@@ -30,7 +30,7 @@ it("Can render longer times", () => {
     expect(formatTime(d, 'the time is %hm!')).toBe('the time is 2!')
     
     expect(formatTime(-d, 'hms')).toBe('-1:40')
-    expect(formatTime(-d, 'hm')).toBe('-2')
+    expect(formatTime(-d, 'hm')).toBe('-1')
     expect(formatTime(-d, 'd')).toBe('0')
 });
 
@@ -49,6 +49,6 @@ it("Can render long times", () => {
     expect(formatTime(d, 'the time is %D:%HH:%MM:%SS')).toBe('the time is 0:02:46:40')
     
     expect(formatTime(-d, 'hms')).toBe('-2:46:40')
-    expect(formatTime(-d, 'hm')).toBe('-2:47')
+    expect(formatTime(-d, 'hm')).toBe('-2:46')
     expect(formatTime(-d, 'h')).toBe('-2')
 });

--- a/test/format-time.test.ts
+++ b/test/format-time.test.ts
@@ -28,7 +28,7 @@ it("Can render longer times", () => {
     expect(formatTime(d, 's')).toBe('100')
     expect(formatTime(d, 'the time is %hms!')).toBe('the time is 1:40!')
     expect(formatTime(d, 'the time is %hm!')).toBe('the time is 2!')
-    
+
     expect(formatTime(-d, 'hms')).toBe('-1:40')
     expect(formatTime(-d, 'hm')).toBe('-1')
     expect(formatTime(-d, 'd')).toBe('0')
@@ -47,9 +47,19 @@ it("Can render long times", () => {
     expect(formatTime(d, 'the time is %s seconds')).toBe('the time is 10000 seconds')
     expect(formatTime(d, 'the time is %D:%H:%M:%S')).toBe('the time is 0:2:46:40')
     expect(formatTime(d, 'the time is %D:%HH:%MM:%SS')).toBe('the time is 0:02:46:40')
-    
+
     expect(formatTime(-d, 'hms')).toBe('-2:46:40')
     expect(formatTime(-d, 'hm')).toBe('-2:46')
     expect(formatTime(-d, 'h')).toBe('-2')
     expect(formatTime(-d, 'm')).toBe('-166')
+    expect(formatTime(-d, 'the time is %d days')).toBe('the time is 0 days')
+    expect(formatTime(-d, 'the time is %m minutes')).toBe('the time is -166 minutes')
+    expect(formatTime(-d, 'the time is %D:%HH:%MM:%SS')).toBe('the time is -0:02:46:40')
+    expect(formatTime(-d, 'the time is %H:%MM:%SS')).toBe('the time is -2:46:40')
+});
+
+it('can render negative times', () => {
+    expect(formatTime(-30, 'hms')).toBe('-30')
+    expect(formatTime(-60, 'hms')).toBe('-1:00')
+    expect(formatTime(-90, 'hms')).toBe('-1:30')
 });

--- a/test/format-time.test.ts
+++ b/test/format-time.test.ts
@@ -28,6 +28,10 @@ it("Can render longer times", () => {
     expect(formatTime(d, 's')).toBe('100')
     expect(formatTime(d, 'the time is %hms!')).toBe('the time is 1:40!')
     expect(formatTime(d, 'the time is %hm!')).toBe('the time is 2!')
+    
+    expect(formatTime(-d, 'hms')).toBe('-1:40')
+    expect(formatTime(-d, 'hm')).toBe('-2')
+    expect(formatTime(-d, 'd')).toBe('0')
 });
 
 it("Can render long times", () => {
@@ -43,4 +47,8 @@ it("Can render long times", () => {
     expect(formatTime(d, 'the time is %s seconds')).toBe('the time is 10000 seconds')
     expect(formatTime(d, 'the time is %D:%H:%M:%S')).toBe('the time is 0:2:46:40')
     expect(formatTime(d, 'the time is %D:%HH:%MM:%SS')).toBe('the time is 0:02:46:40')
+    
+    expect(formatTime(-d, 'hms')).toBe('-2:46:40')
+    expect(formatTime(-d, 'hm')).toBe('-2:47')
+    expect(formatTime(-d, 'h')).toBe('-2')
 });


### PR DESCRIPTION
This is particularly important for timers like Google Home that don'stay while ringing until explicitly dismissed; this lets me see how long the timer was ringing for.

I did not verify that all of the rounding behaves correctly.
