### PR TITLE
Link to more instructions for Alexa

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ I'd love to add it here! Please submit an <a href="https://github.com/rianadon/t
 [#122]: https://github.com/rianadon/timer-bar-card/issues/122
 [#140]: https://github.com/rianadon/timer-bar-card/pull/140
 [#143]: https://github.com/rianadon/timer-bar-card/issues/143
+[#166]: https://github.com/rianadon/timer-bar-card/pull/166
 [Sun]: https://www.home-assistant.io/integrations/sun/
 [Home Assistant timer]: https://www.home-assistant.io/integrations/timer/
 [ThinQ washer/dryer]: https://github.com/ollo69/ha-smartthinq-sensors

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ I'd love to add it here! Please submit an <a href="https://github.com/rianadon/t
 | Automation-controlled<br>switches | *supported & tested* | [set `duration` to `{ fixed: x:xx:xx }`][fixed-duration] |
 | [Sun]                             | *supported*          | [See the example](#sun)                                  |
 | [OpenSprinkler][opensprinkler]    | *supported*          | no! 🎊 ([example][opensprinkler-example])                |
-| [Amazon Alexa Timer]              | *supported*          | `start_time`, `end_time`, and `guess_mode` [[#22]], or [[#164]] |
+| [Amazon Alexa Timer]              | *supported*          | `start_time`, `end_time`, and `guess_mode` [[#22]], or [[#166]] |
 | [Bambu Lab]                       | *supported*          | `active_state`, `end_time` [[#143]] (♡ @andrewtimosca)   |
 | [BMW Connected Drive][bmw]        | *supported*          | `active_state`, `end_time` [[#60]] (♡ @hoeni!)           |
 | [Cleverio Sous Vide (Tuya)]       | *supported*          | multiple: see [#67] (thanks @develop-daraf!)             |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ I'd love to add it here! Please submit an <a href="https://github.com/rianadon/t
 | Automation-controlled<br>switches | *supported & tested* | [set `duration` to `{ fixed: x:xx:xx }`][fixed-duration] |
 | [Sun]                             | *supported*          | [See the example](#sun)                                  |
 | [OpenSprinkler][opensprinkler]    | *supported*          | no! 🎊 ([example][opensprinkler-example])                |
-| [Amazon Alexa Timer]              | *supported*          | `start_time`, `end_time`, and `guess_mode` [[#22]]       |
+| [Amazon Alexa Timer]              | *supported*          | `start_time`, `end_time`, and `guess_mode` [[#22]], or [[#164]] |
 | [Bambu Lab]                       | *supported*          | `active_state`, `end_time` [[#143]] (♡ @andrewtimosca)   |
 | [BMW Connected Drive][bmw]        | *supported*          | `active_state`, `end_time` [[#60]] (♡ @hoeni!)           |
 | [Cleverio Sous Vide (Tuya)]       | *supported*          | multiple: see [#67] (thanks @develop-daraf!)             |


### PR DESCRIPTION
Use the following YAML, with [lovelace-auto-entities](https://github.com/thomasloven/lovelace-auto-entities), to render a card with a separate bar for every timer in every Alexa device in Alexa Media Player.

This renders identically to #140 (except without dismiss buttons, which Alexa does not support).

```yaml
type: custom:auto-entities
filter:
  template: |
    {%- set results = namespace(timers = []) -%}
    {%- set state_map = {
      "ON": "active",
      "PAUSED": "paused",
    } -%}
    {%- set icon_map = {
      "ON": "mdi:timer",
      "ringing": "mdi:timer-alert",
      "PAUSED": "mdi:timer-pause",
    } -%}
    {%- for entity_id in integration_entities('alexa_media') if entity_id
          is contains 'next_timer' -%}
      {%- set multiple = not loop.first or not loop.last -%}
      {%- set suffix = '' if not multiple
                  else ' – ' + state_attr(entity_id, 'friendly_name')
                      | replace(' timers', '') -%}
            
      {%- for kvp in state_attr(entity_id, 'sorted_all') | from_json if kvp[1].status != "OFF" -%}
        {%- set t= kvp[1] -%}
        {%- set label  = t.timerLabel if t.timerLabel else 
            timedelta(milliseconds = t.originalDurationInMillis) | string | regex_replace('^0:0*', '') + ' timer' -%}   
        {%- set results.timers = results.timers + [{
          'icon': icon_map[t.status],
          'duration': {'fixed': t.originalDurationInMillis | int / 1000, 'units': 'seconds'},
          'end_time': {'fixed': (t.triggerTime | int / 1000) | timestamp_local },
          'name': label + suffix,
          'state': {'fixed': state_map[t.status] | default(t.status)},
        }] -%}
      {%- endfor -%}
    {%- endfor -%}
    {{ results.timers }}
card:
  type: custom:timer-bar-card
show_empty: false
```