### PR TITLE
Always return an object in grid options

### DIFF
--- a/src/timer-bar-card.ts
+++ b/src/timer-bar-card.ts
@@ -208,7 +208,7 @@ mushroom??{}} style=${mushroomStyle(config.mushroom??{})} .hass=${this.hass}></t
   /** Taken from lovelace-mushroom */
   public getGridOptions() {
     if (!('mushroom' in this.config)) {
-      return undefined
+      return {};
     }
     if (!this.config.mushroom) {
       return {


### PR DESCRIPTION
Fixes https://github.com/rianadon/timer-bar-card/issues/215