### PR TITLE
Remove unnecessary `node_modules` from import paths

### DIFF
--- a/src/ha-generic-entity-row.ts
+++ b/src/ha-generic-entity-row.ts
@@ -4,8 +4,8 @@
 
 import { css, html, TemplateResult } from "lit";
 import { HomeAssistant } from "custom-card-helpers";
-import { createEntityRow } from "node_modules/card-tools/src/lovelace-element.js";
-import { provideHass } from "node_modules/card-tools/src/hass.js";
+import { createEntityRow } from "card-tools/src/lovelace-element.js";
+import { provideHass } from "card-tools/src/hass.js";
 import { TimerBarEntityConfig } from "./types";
 import { createActionHandler, createHandleAction } from "./helpers-actions";
 


### PR DESCRIPTION
This causes users for people using this library with `rollup` + `rollup-plugin-typescript2` where rollup gets unhappy with these non-ts files we're importing.

See
https://github.com/rianadon/opensprinkler-card/pull/26#issuecomment-3063691859 for details.