### PR TITLE
Treat entity "unknown" states in the same way as "unavailable"

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -116,7 +116,7 @@ export const isState = (stateObj: HassEntity | undefined, checkState: string | s
 }
 
 function nullifyState(value: string) {
-  if (value == "unavailable") return null
+  if (value == "unavailable" || value == "unknown") return null
   return value
 }
 


### PR DESCRIPTION
Should fix #244. When an entity state is _unknown_, the card currently displays an error (even with `debug: true`). I noticed that the function `nullifyState` is not returning `null` in this case, as only handles `unknown`.

This happened for me with a LG diswasher with the official LG ThingQ integration, where most of the entities have an _unknown_ state shortly after the cycle has finished, and interestingly _unavailable_ from Home Assistant start until you turn it on. 